### PR TITLE
Fix shellcheck errors, add dependency check

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Before installing, We need these 3 packages to be installed in your Termux:
  * `unzip` for unzipping Termux Bootstrap.
  * `proot` for start sandboxed environment.
 
-You may do `pkg install [package]` to install those required packages.
+These required packages will be installed if you don't have them.
 
 And finally, set up sandboxed environment:
 
@@ -27,13 +27,13 @@ chmod +x termux-proot.sh
 Uninstalling termux-proot is literally, very easy. 
 
 ```sh
-rm -rf termux-proot.sh
+rm termux-proot.sh
 
 # The command below can use for reinstalling.
 proot -0 rm -rf $PREFIX/../../sandbox
 ```
 
-## Environmenr Variables
+## Environment Variables
 termux-proot also has it's own environment variables and it's changeable. They are:
 
  * `TERMUX_SANDBOX_PATH` - Path to where Termux sandbox folder located. Default is `$PREFIX/../../sandbox`

--- a/termux
+++ b/termux
@@ -1,66 +1,91 @@
-#/usr/bin/env sh
+#!/usr/bin/env bash
 
 # termux-proot - A sandboxed, 2nd termux, isolated or jailed termux environment with proot
 # https://git.io/termux-proot
 
-[ -z $TERMUX_SANDBOX_PATH ] && export TERMUX_SANDBOX_PATH=$PREFIX/../../sandbox 
-[ -z $TERMUX_SANDBOX_APPPATH ] && export TERMUX_SANDBOX_APPPATH=/data/data/com.termux/files
+# Dependency check
+DEPS=("curl" "unzip" "proot")
+for DEP in "${DEPS[@]}"; do
+	if ! hash "$DEP" 2>/dev/null; then
+		echo "$DEP not found, installing..."
+		apt install "$DEP" -y
+	fi
+done
+
+[ -z "$TERMUX_SANDBOX_PATH" ] && export TERMUX_SANDBOX_PATH="$PREFIX"/../../sandbox
+
+[ -z "$TERMUX_SANDBOX_APPPATH" ] && export TERMUX_SANDBOX_APPPATH=/data/data/com.termux/files
+
 [ "$(id -u)" = "0" ] && exec echo -e "You shouldn't execute this script as root, don't you?\nSo you're trying to harm your own Device.\n\nAbility to use termux-proot with root (even fake) is disabled permanently.\nJust do it in your real termux, Or use chroot. But don't blame me for broken device OK?"
 
 # { Installation }
-[ $(uname -o) != "Android" ] && exec echo "Sorry. This script is only executeable on Android. Use Termux to exexute this or use termux-docker."
-! [ -d $TERMUX_SANDBOX_PATH ] || [ -z "$(ls -A $TERMUX_SANDBOX_PATH)" ] && {
-	! [ -f ${TMPDIR:-/tmp}/.termux-rootfs.zip ] && echo "[#  ] Downloading Latest Termux Bootstrap...." && curl -#Lo ${TMPDIR:-/tmp}/.termux-rootfs.zip https://github.com/termux/termux-packages/releases/download/$(curl -s "https://api.github.com/repos/termux/termux-packages/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')/bootstrap-$(dpkg --print-architecture).zip
-	mkdir $TERMUX_SANDBOX_PATH && cd $TERMUX_SANDBOX_PATH
+[ "$(uname -o)" != "Android" ] && exec echo "Sorry. This script is only executable on Android. Use Termux to exexute this or use termux-docker."
+
+if [ ! -d "$TERMUX_SANDBOX_PATH" ] || [ -z "$(ls -A "$TERMUX_SANDBOX_PATH")" ]; then
+	if [ ! -f "${TMPDIR:-/tmp}"/.termux-rootfs.zip ]; then
+		echo "[#  ] Downloading Latest Termux Bootstrap...."
+		curl -Lo "${TMPDIR:-/tmp}"/.termux-rootfs.zip https://github.com/termux/termux-packages/releases/download/"$(curl -s "https://api.github.com/repos/termux/termux-packages/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')"/bootstrap-"$(dpkg --print-architecture)".zip
+	fi
+	mkdir "$TERMUX_SANDBOX_PATH" && cd "$TERMUX_SANDBOX_PATH" || exit 1
 
 	echo -n "[## ] Extracting.... "
-	unzip -q ${TMPDIR:-/tmp}/.termux-rootfs.zip
-
-	[ $? != 0 ] && echo Fail && proot -0 rm -rf $TERMUX_SANDBOX_PATH && exit 6
-	echo Done
+	if ! unzip -q "${TMPDIR:-/tmp}"/.termux-rootfs.zip; then
+		echo "Failed extracting bootstrap!"
+		proot -0 rm -rf "$TERMUX_SANDBOX_PATH"
+		exit 6
+	fi
+	echo "Done"
 
 	echo -n "[###] Symlinking.... "
-	while read p; do
-		ln -s ${p/←/ }
-	done <SYMLINKS.txt && rm SYMLINKS.txt
-	echo Done
-}
+	while read -r p; do
+		IFS="←" read -r FILE DEST <<< "$p"
+		ln -s "$FILE" "$DEST"
+	done < SYMLINKS.txt && rm SYMLINKS.txt
+	echo "Done"
+fi
 
-ARGS=proot
-ARGS="$ARGS --kill-on-exit -r $TERMUX_SANDBOX_PATH $TERMUX_SANDBOX_PROOT_OPTIONS"
+ARGS=("proot")
+ARGS+=("--kill-on-exit -r $TERMUX_SANDBOX_PATH $TERMUX_SANDBOX_PROOT_OPTIONS")
 
 # Make sure that some common directory like /home is there.
 # Otherwise, we recreate the directory
 for dir in $TERMUX_SANDBOX_PATH/var/cache $TERMUX_SANDBOX_PATH/home $TERMUX_SANDBOX_PATH/sdcard; do
-	! [ -d $dir ] && mkdir $dir
+	! [ -d "$dir" ] && mkdir "$dir"
 done
 
 # Bind some common path
 for bind in /dev /proc /sys /system /vendor /apex /linkerconfig/ld.config.txt /property_context $TERMUX_SANDBOX_PATH:$TERMUX_SANDBOX_APPPATH/usr $TERMUX_SANDBOX_PATH/var/cache:/data/data/com.termux/cache $TERMUX_SANDBOX_PATH/home:$TERMUX_SANDBOX_APPPATH/home; do
-	[ -d $bind ] || [ -f $bind ] || echo $bind | grep com.termux > /dev/null && ARGS="$ARGS -b $bind"
+	[ -d "$bind" ] || [ -f "$bind" ] || grep -q com.termux <<< "$bind" && ARGS+=("-b $bind")
 done
 
-ARGS="$ARGS -w $TERMUX_SANDBOX_APPPATH/home"
-ARGS="$ARGS $TERMUX_SANDBOX_APPPATH/usr/bin/env -i"
-ARGS="$ARGS HOME=$TERMUX_SANDBOX_APPPATH/home"
-ARGS="$ARGS PATH=$TERMUX_SANDBOX_APPPATH/usr/bin"
-ARGS="$ARGS TERM=${TERM:-xterm-256color}"
-ARGS="$ARGS COLORTERM=${COLORTERM:-truecolor}"
-ARGS="$ARGS ANDROID_DATA=/data"
-ARGS="$ARGS ANDROID_ROOT=/system"
-ARGS="$ARGS EXTERNAL_STORAGE=/sdcard"
-ARGS="$ARGS LANG=${LANG:-en_US.UTF-8}"
-ARGS="$ARGS LD_LIBRARY_PATH=$TERMUX_SANDBOX_APPPATH/usr/lib"
-[ -x $TERMUX_SANDBOX_APPPATH/usr/lib/libtermux-exec.so ] && ARGS="$ARGS LD_PRELOAD=$TERMUX_SANDBOX_APPPATH/usr/lib/libtermux-exec.so"
-ARGS="$ARGS TERMUX_VERSION=${TERMUX_VERSION:-0.118}"
-ARGS="$ARGS PREFIX=$TERMUX_SANDBOX_APPPATH/usr"
-ARGS="$ARGS TMPDIR=$TERMUX_SANDBOX_APPPATH/usr/tmp"
-ARGS="$ARGS $TERMUX_SANDBOX_ENV"
+ARGS+=("-w $TERMUX_SANDBOX_APPPATH/home")
+ARGS+=("$TERMUX_SANDBOX_APPPATH/usr/bin/env -i")
+ARGS+=("HOME=$TERMUX_SANDBOX_APPPATH/home")
+ARGS+=("PATH=$TERMUX_SANDBOX_APPPATH/usr/bin")
+ARGS+=("TERM=${TERM:-xterm-256color}")
+ARGS+=("COLORTERM=${COLORTERM:-truecolor}")
+ARGS+=("ANDROID_DATA=/data")
+ARGS+=("ANDROID_ROOT=/system")
+ARGS+=("EXTERNAL_STORAGE=/sdcard")
+ARGS+=("LANG=${LANG:-en_US.UTF-8}")
+ARGS+=("LD_LIBRARY_PATH=$TERMUX_SANDBOX_APPPATH/usr/lib")
+[ -x "$TERMUX_SANDBOX_APPPATH"/usr/lib/libtermux-exec.so ] && ARGS+=("LD_PRELOAD=$TERMUX_SANDBOX_APPPATH/usr/lib/libtermux-exec.so")
+ARGS+=("TERMUX_VERSION=${TERMUX_VERSION:-0.118}")
+ARGS+=("PREFIX=$TERMUX_SANDBOX_APPPATH/usr")
+ARGS+=("TMPDIR=$TERMUX_SANDBOX_APPPATH/usr/tmp")
+ARGS+=("$TERMUX_SANDBOX_ENV")
 
-cmd="$@"
+cmd="$*"
 
 # Unset Preload Library.
 unset LD_PRELOAD
 
-[ -z "$cmd" ] && exec $ARGS /bin/login
-! [ -z "$cmd" ] && exec $ARGS /bin/login -c "$cmd"
+# shellcheck disable=SC2068
+case "$cmd" in
+"")
+	exec ${ARGS[@]} /bin/login
+	;;
+*)
+	exec ${ARGS[@]} /bin/login -c "$cmd"
+	;;
+esac


### PR DESCRIPTION
# List of errors / warnings fixed:
*  Use #!, not just #, for the shebang.
* Double quote to prevent globbing and word splitting.
* In POSIX sh, echo flags are undefined.
* In POSIX sh, string replacement is undefined.
* Use `cd ... || exit` or `cd ... || return` in case cd fails.
* Check exit code directly with e.g. `if ! mycmd;`, not indirectly with `$?`.
* read without `-r` will mangle backslashes
* Assigning an array to a string! Assign as array, or use `$*` instead of `$@` to concatenate.
* Use `[ -n .. ]` instead of `! [ -z .. ]`.

# Other
* Added a dependency check
* Fixed typo in `README` _[ Environmenr -> Environment ]_

Signed-off-by: Pero Sar <perosar1111@gmail.com>